### PR TITLE
Undo last change.

### DIFF
--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -191,8 +191,6 @@
 #endif
 
 #include "utf_mapper.h"
-   
- void lcd_impletmentation_hotend_status();
 
 int lcd_contrast;
 static char currentfont = 0;


### PR DESCRIPTION
Reverting the `void lcd_impletmentation_hotend_status();` change to the `ultralcd_impl_DOGM.h` file.